### PR TITLE
AWS provider improvements 

### DIFF
--- a/src/features/upload-file/providers/aws-provider.ts
+++ b/src/features/upload-file/providers/aws-provider.ts
@@ -34,6 +34,12 @@ export type AWSOptions = {
    * Default to 24h. If set to 0 adapter will mark uploaded files as PUBLIC ACL.
    */
   expires?: number;
+  
+  /**
+   * Allows to override 'https://${bucket}.s3.amazonaws.com' for previews in admin
+   * mihgt be usefull for buckets served via CDN and static website hosting, e.g. https://support.cloudflare.com/hc/en-us/articles/360037983412-Configuring-an-Amazon-Web-Services-static-site-to-use-Cloudflare
+   */
+  previewBaseUrl?: string
 }
 
 export class AWSProvider extends BaseProvider {
@@ -54,6 +60,7 @@ export class AWSProvider extends BaseProvider {
     }
     this.expires = options.expires ?? DAY_IN_MINUTES
     this.s3 = new AWS_S3(options)
+    this.previewBaseUrl = options.previewBaseUrl;
   }
 
   public async upload(file: UploadedFile, key: string): Promise<S3.ManagedUpload.SendData> {
@@ -83,6 +90,6 @@ export class AWSProvider extends BaseProvider {
       })
     }
     // https://bucket.s3.amazonaws.com/key
-    return `https://${bucket}.s3.amazonaws.com/${key}`
+    return this.previewBaseUrl || `https://${bucket}.s3.amazonaws.com/${key}`
   }
 }

--- a/src/features/upload-file/providers/aws-provider.ts
+++ b/src/features/upload-file/providers/aws-provider.ts
@@ -47,6 +47,8 @@ export class AWSProvider extends BaseProvider {
 
   public expires: number
 
+  private previewBaseUrl: string | undefined
+
   constructor(options: AWSOptions) {
     super(options.bucket)
 
@@ -70,6 +72,7 @@ export class AWSProvider extends BaseProvider {
       Bucket: this.bucket,
       Key: key,
       Body: tmpFile,
+      ContentType: file.type
     }
     if (!this.expires) {
       params.ACL = 'public-read'
@@ -90,6 +93,10 @@ export class AWSProvider extends BaseProvider {
       })
     }
     // https://bucket.s3.amazonaws.com/key
-    return this.previewBaseUrl || `https://${bucket}.s3.amazonaws.com/${key}`
+    let base : string = `https://${bucket}.s3.amazonaws.com`;
+    if (this.previewBaseUrl) {
+      base = this.previewBaseUrl;
+    }
+    return `${base}/${key}`
   }
 }


### PR DESCRIPTION
1) Add previewBaseUrl, which allows overriding hardcoded 'https://${bucket}.s3.amazonaws.com' why:
This allows specifying URL for buckets served via CDN and static website hosting, example of such hosting https://support.cloudflare.com/hc/en-us/articles/360037983412-Configuring-an-Amazon-Web-Services-static-site-to-use-Cloudflare
For example, if my S3 bucket is named `static.example.com` then I will not be able to get it's public files (with public-read ACL) using `https://${bucket}.s3.amazonaws.com/myfile.png` ->  `https://static.example.com.s3.amazonaws.com/myfile.png`, because buckets with dot's not covered by AWS SSL certificate. To fix this you might also want to use `https://s3.${region}.amazonaws.com/${bucket}/myfile.png` - here we use a standard domain, which has a good certificate, I would recommend using this endpoint because this is more universal (I did not perform this in pull request because probably you also other reasons, and my current option is backward compatible for all existing installations)
But ideally, me and other users who are serving S3 buckets via CDN, need the ability to load images from https://static.example.com/myfile.png (it preaches images on CDN and makes URLs more similar to those which we use in prod

2) I added Content-Type Metadata to s3 which is useful in multiple cases. For example, when you upload SVGs, S3 sets System Content-Type application/octet-stream which brakes disposition and is subject to CORB
