### PR TITLE
Update local-provider.ts

### DIFF
--- a/src/features/upload-file/providers/local-provider.ts
+++ b/src/features/upload-file/providers/local-provider.ts
@@ -33,7 +33,8 @@ export class LocalProvider extends BaseProvider {
     const filePath = process.platform === 'win32' ? this.path(key) : this.path(key).slice(1) // adjusting file path according to OS
 
     await fs.promises.mkdir(path.dirname(filePath), { recursive: true })
-    await fs.promises.rename(file.path, filePath)
+    await fs.promises.copyFile(file.path, filePath) //Changed for Error: EXDEV: cross-device link not permitted
+    await fs.promises.unlink(file.path)
   }
 
   public async delete(key: string, bucket: string): Promise<any> {


### PR DESCRIPTION
This is a patch because of the error mentioned in code. sometimes /tmp is in a different partition. This is a replication of fs.promises.rename that works the same way. Hope this helps!